### PR TITLE
Use HTTPS urls in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
   <licenses>
     <license>
       <name>MIT License</name>
-      <url>http://opensource.org/licenses/MIT</url>
+      <url>https://opensource.org/licenses/MIT</url>
     </license>
   </licenses>
 

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <repository>
       <id>spring-snapshots</id>
       <name>Spring Snapshots</name>
-      <url>http://repo.spring.io/snapshot</url>
+      <url>https://repo.spring.io/snapshot</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
   </developers>
 
   <scm>
-    <connection>scm:git:git://git@github.com/jenkinsci/hcl-accelerate-plugin.git</connection>
+    <connection>scm:git:https://git@github.com/jenkinsci/hcl-accelerate-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/hcl-accelerate-plugin.git</developerConnection>
     <tag>hcl-accelerate-2.0.0</tag>
   </scm>


### PR DESCRIPTION
## Use HTTPS urls in pom

* Use HTTPS url to Spring repo to compile with Maven 3.8.x
* Use HTTPS to access Jenkins artifact repository to compile with Maven 3.8.x
* Use HTTPS URL to license location as common practive
* Use HTTPS URL to public git repository prepare for GitHub deprecation of git:// protocol
